### PR TITLE
fix(v-test): fix test reloading problem

### DIFF
--- a/src/utils/actions.utils.js
+++ b/src/utils/actions.utils.js
@@ -1,16 +1,16 @@
 export function shuffle(array) {
-  let m = array.length, t, i
+  let arrayLength = array.length, aux, randomPos
 
-  // While there remain elements to shuffle…
-  while (m) {
+  // While there remain elements to shuffle...
+  while (arrayLength) {
 
-    // Pick a remaining element…
-    i = Math.floor(Math.random() * m--)
+    // Pick a remaining element...
+    randomPos = Math.floor(Math.random() * arrayLength--)
 
     // And swap it with the current element.
-    t = array[m]
-    array[m] = array[i]
-    array[i] = t
+    aux = array[arrayLength]
+    array[arrayLength] = array[randomPos]
+    array[randomPos] = aux
   }
 
   return array

--- a/src/views/v-test/v-test.style.scss
+++ b/src/views/v-test/v-test.style.scss
@@ -1,5 +1,6 @@
 @import '../../styles/tools/tools.grid.scss';
 @import '../../styles/tools/tools.margins.scss';
+@import '../../styles/tools/tools.typography.scss';
 
 .v-test {
   &__head {
@@ -29,12 +30,6 @@
 
   &__file {
     display: none;
-  }
-
-  &__reload {
-    position: fixed;
-    top: space(1);
-    right: space(1);
   }
 
   &__form {
@@ -101,5 +96,16 @@
       color: var(--color-error);
       font-weight: 700;
     }
+  }
+
+  &__bottom {
+    display: flex;
+
+  }
+
+  &__result {
+    @include text;
+    color: var(--color-black);
+    margin-left: space(2);
   }
 }


### PR DESCRIPTION
Some fixes and improvement have been implemented:

- Fix options shuffle from every questions.
- Refactor `shuffle` utility function to improve it's legibility.
- Improve legibility of warning message about questions not answered.
- Move reload bottom position to bottom and apply secondary theme.
- Add message to indicate user how many questions are success